### PR TITLE
Replace frontend with Next app and harden API

### DIFF
--- a/backend/catalog/views.py
+++ b/backend/catalog/views.py
@@ -2,10 +2,16 @@ from rest_framework import viewsets, mixins, permissions
 from .models import Product, Order
 from .serializers import ProductSerializer, OrderCreateSerializer
 
-class ProductViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+class ProductViewSet(
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
     queryset = Product.objects.filter(published=True).order_by("-created_at")
     serializer_class = ProductSerializer
     permission_classes = [permissions.AllowAny]
+    lookup_field = "slug"
+    lookup_value_regex = r"[\w-]+"
 
 class OrderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     queryset = Order.objects.all().order_by("-created_at")

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import os
+import importlib
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -8,11 +9,17 @@ DEBUG = os.getenv("DEBUG", "True") == "True"
 ALLOWED_HOSTS = ["127.0.0.1", "localhost"]  # add your domain on deploy
 
 INSTALLED_APPS = [
-    "django.contrib.admin","django.contrib.auth","django.contrib.contenttypes",
-    "django.contrib.sessions","django.contrib.messages","django.contrib.staticfiles",
-    "jazzmin",  
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
     "catalog",  # our shop app
 ]
+
+if importlib.util.find_spec("jazzmin"):
+    INSTALLED_APPS.insert(0, "jazzmin")
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ Django>=5.0
 djangorestframework
 djangorestframework-simplejwt
 django-cors-headers
+jazzmin
 psycopg[binary]
 gunicorn
 whitenoise

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next", "next/core-web-vitals"],
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
+}

--- a/frontend/app/cart/page.tsx
+++ b/frontend/app/cart/page.tsx
@@ -1,0 +1,7 @@
+import { CartPage } from "@/components/cart-page";
+
+export const revalidate = 0;
+
+export default function CartRoute() {
+  return <CartPage />;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import "@/styles/globals.css";
+import { CartProvider } from "@/components/cart-context";
+import { Header } from "@/components/header";
+import { Footer } from "@/components/footer";
+
+export const metadata: Metadata = {
+  title: "Storefront",
+  description: "Simple storefront powered by Django and Next.js"
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <CartProvider>
+          <Header />
+          <main>{children}</main>
+          <Footer />
+        </CartProvider>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,14 @@
+import { Suspense } from "react";
+import { ProductList } from "@/components/product-list";
+import { ProductsFallback } from "@/components/products-fallback";
+
+export default function HomePage() {
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1 style={{ fontSize: "2rem", marginBottom: "1rem" }}>Products</h1>
+      <Suspense fallback={<ProductsFallback message="Loading products…" /> }>
+        <ProductList />
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/app/products/[slug]/page.tsx
+++ b/frontend/app/products/[slug]/page.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getProduct } from "@/lib/api";
+import { ProductDetail } from "@/components/product-detail";
+import { ProductsFallback } from "@/components/products-fallback";
+
+interface ProductPageProps {
+  params: { slug: string };
+}
+
+export const revalidate = 0;
+
+export default async function ProductPage({ params }: ProductPageProps) {
+  const result = await getProduct(params.slug);
+
+  if (result.status === 404) {
+    notFound();
+  }
+
+  if (result.error || !result.data) {
+    return (
+      <div style={{ padding: "2rem" }}>
+        <ProductsFallback message={result.error ?? "Product unavailable."} isError />
+        <p style={{ marginTop: "1rem" }}>
+          <Link href="/">Back to products</Link>
+        </p>
+      </div>
+    );
+  }
+
+  return <ProductDetail product={result.data} />;
+}

--- a/frontend/components/cart-context.tsx
+++ b/frontend/components/cart-context.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer
+} from "react";
+import type { Product } from "@/lib/types";
+
+const STORAGE_KEY = "shop-cart-v1";
+
+type CartItem = {
+  id: string;
+  slug: string;
+  title: string;
+  price_cents: number;
+  quantity: number;
+};
+
+type CartState = {
+  items: CartItem[];
+  hydrated: boolean;
+};
+
+type CartAction =
+  | { type: "hydrate"; payload: CartItem[] }
+  | { type: "add"; payload: { product: Product; quantity: number } }
+  | { type: "update"; payload: { id: string; quantity: number } }
+  | { type: "remove"; payload: { id: string } }
+  | { type: "clear" };
+
+const initialState: CartState = {
+  items: [],
+  hydrated: false
+};
+
+function cartReducer(state: CartState, action: CartAction): CartState {
+  switch (action.type) {
+    case "hydrate":
+      return {
+        items: action.payload,
+        hydrated: true
+      };
+    case "add": {
+      const { product, quantity } = action.payload;
+      const existing = state.items.find((item) => item.id === product.id);
+      const nextItems = existing
+        ? state.items.map((item) =>
+            item.id === product.id
+              ? { ...item, quantity: item.quantity + quantity }
+              : item
+          )
+        : [
+            ...state.items,
+            {
+              id: product.id,
+              slug: product.slug,
+              title: product.title,
+              price_cents: product.price_cents,
+              quantity
+            }
+          ];
+      return { ...state, items: nextItems };
+    }
+    case "update": {
+      const { id, quantity } = action.payload;
+      const nextItems = state.items
+        .map((item) =>
+          item.id === id ? { ...item, quantity: Math.max(1, quantity) } : item
+        )
+        .filter((item) => item.quantity > 0);
+      return { ...state, items: nextItems };
+    }
+    case "remove":
+      return {
+        ...state,
+        items: state.items.filter((item) => item.id !== action.payload.id)
+      };
+    case "clear":
+      return { ...state, items: [] };
+    default:
+      return state;
+  }
+}
+
+type CartContextValue = {
+  items: CartItem[];
+  hydrated: boolean;
+  addItem: (product: Product, quantity?: number) => void;
+  updateItem: (id: string, quantity: number) => void;
+  removeItem: (id: string) => void;
+  clear: () => void;
+  totalCents: number;
+};
+
+const CartContext = createContext<CartContextValue | null>(null);
+
+export function CartProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(cartReducer, initialState);
+
+  useEffect(() => {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as CartItem[];
+        dispatch({ type: "hydrate", payload: parsed });
+        return;
+      } catch (error) {
+        console.warn("Failed to parse cart from storage", error);
+      }
+    }
+    dispatch({ type: "hydrate", payload: [] });
+  }, []);
+
+  useEffect(() => {
+    if (!state.hydrated) {
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state.items));
+  }, [state.items, state.hydrated]);
+
+  const addItem = useCallback(
+    (product: Product, quantity = 1) => {
+      dispatch({ type: "add", payload: { product, quantity } });
+    },
+    [dispatch]
+  );
+
+  const updateItem = useCallback((id: string, quantity: number) => {
+    dispatch({ type: "update", payload: { id, quantity } });
+  }, []);
+
+  const removeItem = useCallback((id: string) => {
+    dispatch({ type: "remove", payload: { id } });
+  }, []);
+
+  const clear = useCallback(() => {
+    dispatch({ type: "clear" });
+  }, []);
+
+  const totalCents = useMemo(
+    () => state.items.reduce((acc, item) => acc + item.price_cents * item.quantity, 0),
+    [state.items]
+  );
+
+  const value = useMemo(
+    () => ({
+      items: state.items,
+      hydrated: state.hydrated,
+      addItem,
+      updateItem,
+      removeItem,
+      clear,
+      totalCents
+    }),
+    [state.items, state.hydrated, addItem, updateItem, removeItem, clear, totalCents]
+  );
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+}
+
+export function useCart() {
+  const ctx = useContext(CartContext);
+  if (!ctx) {
+    throw new Error("useCart must be used within CartProvider");
+  }
+  return ctx;
+}
+
+export type { CartItem };

--- a/frontend/components/cart-page.module.css
+++ b/frontend/components/cart-page.module.css
@@ -1,0 +1,149 @@
+.wrapper {
+  padding: 2rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.layout {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
+.items ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: #ffffff;
+  border-radius: 1rem;
+  padding: 1rem 1.5rem;
+  border: 1px solid #e5e7eb;
+}
+
+.itemTitle {
+  margin: 0;
+  font-weight: 600;
+}
+
+.itemPrice {
+  margin: 0.25rem 0 0;
+  color: #4b5563;
+}
+
+.itemActions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.itemActions label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.itemActions input {
+  margin-top: 0.25rem;
+  width: 80px;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid #d1d5db;
+}
+
+.itemActions button {
+  background-color: transparent;
+  border: none;
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.itemActions button:hover,
+.itemActions button:focus-visible {
+  text-decoration: underline;
+}
+
+.total {
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.formSection {
+  background-color: #ffffff;
+  border-radius: 1rem;
+  padding: 2rem;
+  border: 1px solid #e5e7eb;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.form input,
+.form textarea {
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid #d1d5db;
+}
+
+.form button {
+  align-self: flex-start;
+  background-color: #2563eb;
+  color: #ffffff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+}
+
+.form button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.form button:not(:disabled):hover,
+.form button:not(:disabled):focus-visible {
+  background-color: #1d4ed8;
+}
+
+.error {
+  color: #b91c1c;
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+.success {
+  color: #047857;
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+.empty {
+  background-color: #ffffff;
+  border-radius: 1rem;
+  padding: 2rem;
+  border: 1px solid #e5e7eb;
+}
+
+.empty a {
+  color: #2563eb;
+  font-weight: 600;
+}

--- a/frontend/components/cart-page.tsx
+++ b/frontend/components/cart-page.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useCart } from "@/components/cart-context";
+import { createOrder } from "@/lib/api";
+import { formatCurrency } from "@/lib/util";
+import styles from "./cart-page.module.css";
+
+export function CartPage() {
+  const { items, hydrated, updateItem, removeItem, totalCents, clear } = useCart();
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState("");
+  const [error, setError] = useState("");
+  const hasItems = hydrated && items.length > 0;
+
+  const [form, setForm] = useState({
+    customer_name: "",
+    phone: "",
+    address: "",
+    note: ""
+  });
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!hasItems || submitting) {
+      return;
+    }
+    setSubmitting(true);
+    setError("");
+    setSuccess("");
+
+    const payload = {
+      customer_name: form.customer_name.trim(),
+      phone: form.phone.trim(),
+      address: form.address.trim(),
+      note: form.note.trim(),
+      items: items.map((item) => ({ product: item.id, quantity: item.quantity }))
+    };
+
+    if (!payload.customer_name || !payload.phone || !payload.address) {
+      setError("Please fill in your name, phone and delivery address before submitting.");
+      setSubmitting(false);
+      return;
+    }
+
+    const response = await createOrder(payload);
+
+    if (!response.ok) {
+      setError(response.error ?? "We could not submit your order.");
+      setSubmitting(false);
+      return;
+    }
+
+    clear();
+    setSuccess("Thank you! Your order has been submitted.");
+    setForm({ customer_name: "", phone: "", address: "", note: "" });
+    setSubmitting(false);
+  };
+
+  const cartTotal = useMemo(() => formatCurrency(totalCents), [totalCents]);
+
+  return (
+    <div className={styles.wrapper}>
+      <h1>Your cart</h1>
+      {!hydrated ? (
+        <p>Loading cart…</p>
+      ) : hasItems ? (
+        <div className={styles.layout}>
+          <section className={styles.items}>
+            <ul>
+              {items.map((item) => (
+                <li key={item.id} className={styles.item}>
+                  <div>
+                    <p className={styles.itemTitle}>{item.title}</p>
+                    <p className={styles.itemPrice}>{formatCurrency(item.price_cents)}</p>
+                  </div>
+                  <div className={styles.itemActions}>
+                    <label>
+                      Qty
+                      <input
+                        type="number"
+                        min={1}
+                        value={item.quantity}
+                        onChange={(event) =>
+                          updateItem(item.id, Number(event.target.value) || item.quantity)
+                        }
+                      />
+                    </label>
+                    <button type="button" onClick={() => removeItem(item.id)}>
+                      Remove
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+            <p className={styles.total}>Total: {cartTotal}</p>
+          </section>
+          <section className={styles.formSection}>
+            <h2>Checkout</h2>
+            <form onSubmit={handleSubmit} className={styles.form}>
+              <label>
+                Full name
+                <input
+                  name="customer_name"
+                  value={form.customer_name}
+                  onChange={handleChange}
+                  required
+                  disabled={submitting}
+                />
+              </label>
+              <label>
+                Phone number
+                <input
+                  name="phone"
+                  value={form.phone}
+                  onChange={handleChange}
+                  required
+                  disabled={submitting}
+                />
+              </label>
+              <label>
+                Delivery address
+                <input
+                  name="address"
+                  value={form.address}
+                  onChange={handleChange}
+                  required
+                  disabled={submitting}
+                />
+              </label>
+              <label>
+                Additional note
+                <textarea
+                  name="note"
+                  value={form.note}
+                  onChange={handleChange}
+                  rows={3}
+                  disabled={submitting}
+                />
+              </label>
+              <button type="submit" disabled={submitting}>
+                {submitting ? "Submitting…" : "Place order"}
+              </button>
+            </form>
+            {error ? (
+              <p className={styles.error} role="alert">
+                {error}
+              </p>
+            ) : null}
+            {success ? <p className={styles.success}>{success}</p> : null}
+          </section>
+        </div>
+      ) : (
+        <div className={styles.empty}>
+          <p>Your cart is empty.</p>
+          <Link href="/">Browse products</Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/footer.module.css
+++ b/frontend/components/footer.module.css
@@ -1,0 +1,6 @@
+.footer {
+  margin-top: 4rem;
+  padding: 2rem;
+  text-align: center;
+  color: #6b7280;
+}

--- a/frontend/components/footer.tsx
+++ b/frontend/components/footer.tsx
@@ -1,0 +1,9 @@
+import styles from "./footer.module.css";
+
+export function Footer() {
+  return (
+    <footer className={styles.footer}>
+      <p>© {new Date().getFullYear()} Fresh Store. All rights reserved.</p>
+    </footer>
+  );
+}

--- a/frontend/components/header.module.css
+++ b/frontend/components/header.module.css
@@ -1,0 +1,31 @@
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background-color: #ffffff;
+  border-bottom: 1px solid #e5e7eb;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.brand {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.navLink {
+  font-weight: 500;
+  color: #2563eb;
+}
+
+.navLink:hover,
+.navLink:focus-visible {
+  text-decoration: underline;
+}

--- a/frontend/components/header.tsx
+++ b/frontend/components/header.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import Link from "next/link";
+import { useCart } from "@/components/cart-context";
+import styles from "./header.module.css";
+
+export function Header() {
+  const { items } = useCart();
+  const itemCount = items.reduce((acc, item) => acc + item.quantity, 0);
+
+  return (
+    <header className={styles.header}>
+      <Link href="/" className={styles.brand}>
+        Fresh Store
+      </Link>
+      <nav className={styles.nav} aria-label="Main navigation">
+        <Link href="/" className={styles.navLink}>
+          Products
+        </Link>
+        <Link href="/cart" className={styles.navLink}>
+          Cart {itemCount > 0 ? `(${itemCount})` : ""}
+        </Link>
+      </nav>
+    </header>
+  );
+}

--- a/frontend/components/product-card.module.css
+++ b/frontend/components/product-card.module.css
@@ -1,0 +1,53 @@
+.card {
+  background-color: #ffffff;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  border: 1px solid #e5e7eb;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 10px 24px -12px rgba(15, 23, 42, 0.35);
+}
+
+.heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.price {
+  font-weight: 600;
+  color: #059669;
+}
+
+.description {
+  color: #4b5563;
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.link {
+  color: #2563eb;
+  font-weight: 500;
+}
+
+.button {
+  background-color: #059669;
+  color: #ffffff;
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.5rem 1.25rem;
+  font-weight: 600;
+}
+
+.button:hover,
+.button:focus-visible {
+  background-color: #047857;
+}

--- a/frontend/components/product-card.tsx
+++ b/frontend/components/product-card.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import type { Product } from "@/lib/types";
+import { useCart } from "@/components/cart-context";
+import styles from "./product-card.module.css";
+import { formatCurrency } from "@/lib/util";
+
+export function ProductCard({ product }: { product: Product }) {
+  const { addItem } = useCart();
+  const [added, setAdded] = useState(false);
+
+  const handleAdd = () => {
+    addItem(product, 1);
+    setAdded(true);
+    setTimeout(() => setAdded(false), 1500);
+  };
+
+  return (
+    <article className={styles.card}>
+      <div className={styles.heading}>
+        <h2>{product.title}</h2>
+        <p className={styles.price}>{formatCurrency(product.price_cents)}</p>
+      </div>
+      {product.description ? (
+        <p className={styles.description}>{product.description}</p>
+      ) : null}
+      <div className={styles.actions}>
+        <Link href={`/products/${product.slug}`} className={styles.link}>
+          View details
+        </Link>
+        <button type="button" className={styles.button} onClick={handleAdd}>
+          {added ? "Added" : "Add to cart"}
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/frontend/components/product-detail.module.css
+++ b/frontend/components/product-detail.module.css
@@ -1,0 +1,84 @@
+.wrapper {
+  padding: 2rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.backLink {
+  display: inline-block;
+  margin-bottom: 1rem;
+  color: #2563eb;
+}
+
+.card {
+  background-color: #ffffff;
+  border-radius: 1rem;
+  padding: 2rem;
+  border: 1px solid #e5e7eb;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.header h1 {
+  margin: 0;
+}
+
+.price {
+  font-size: 1.5rem;
+  color: #059669;
+  font-weight: 600;
+}
+
+.description {
+  margin: 0;
+  color: #4b5563;
+  line-height: 1.6;
+}
+
+.form {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 500;
+  gap: 0.5rem;
+}
+
+.label input {
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid #d1d5db;
+  width: 120px;
+}
+
+.form button {
+  border: none;
+  background-color: #059669;
+  color: #ffffff;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.form button:hover,
+.form button:focus-visible {
+  background-color: #047857;
+}
+
+.confirmation {
+  margin: 0;
+  color: #047857;
+  font-weight: 500;
+}

--- a/frontend/components/product-detail.tsx
+++ b/frontend/components/product-detail.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import type { Product } from "@/lib/types";
+import { useCart } from "@/components/cart-context";
+import { formatCurrency } from "@/lib/util";
+import styles from "./product-detail.module.css";
+
+export function ProductDetail({ product }: { product: Product }) {
+  const { addItem } = useCart();
+  const [quantity, setQuantity] = useState(1);
+  const [confirmation, setConfirmation] = useState("");
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    addItem(product, quantity);
+    setConfirmation("Added to cart!");
+    setTimeout(() => setConfirmation(""), 2000);
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <Link href="/" className={styles.backLink}>
+        ← Back to products
+      </Link>
+      <article className={styles.card}>
+        <header className={styles.header}>
+          <h1>{product.title}</h1>
+          <p className={styles.price}>{formatCurrency(product.price_cents)}</p>
+        </header>
+        {product.description ? (
+          <p className={styles.description}>{product.description}</p>
+        ) : (
+          <p className={styles.description}>
+            This product does not have a detailed description yet, but it is available for
+            purchase.
+          </p>
+        )}
+        <form className={styles.form} onSubmit={handleSubmit}>
+          <label className={styles.label}>
+            Quantity
+            <input
+              type="number"
+              min={1}
+              value={quantity}
+              onChange={(event) => setQuantity(Number(event.target.value) || 1)}
+            />
+          </label>
+          <button type="submit">Add to cart</button>
+        </form>
+        {confirmation ? <p className={styles.confirmation}>{confirmation}</p> : null}
+      </article>
+    </div>
+  );
+}

--- a/frontend/components/product-list.tsx
+++ b/frontend/components/product-list.tsx
@@ -1,0 +1,30 @@
+import { getProducts } from "@/lib/api";
+import { ProductsFallback } from "@/components/products-fallback";
+import { ProductCard } from "@/components/product-card";
+
+export async function ProductList() {
+  const { data, error } = await getProducts();
+
+  if (error) {
+    return <ProductsFallback message={error} isError />;
+  }
+
+  if (!data.length) {
+    return <ProductsFallback message="No products have been published yet." />;
+  }
+
+  return (
+    <div className="product-grid">
+      {data.map((product) => (
+        <ProductCard key={product.id} product={product} />
+      ))}
+      <style jsx>{`
+        .product-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+          gap: 1.5rem;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/components/products-fallback.tsx
+++ b/frontend/components/products-fallback.tsx
@@ -1,0 +1,21 @@
+export function ProductsFallback({
+  message,
+  isError = false
+}: {
+  message: string;
+  isError?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        padding: "2rem",
+        borderRadius: "0.75rem",
+        backgroundColor: isError ? "#fee2e2" : "#e0f2fe",
+        color: isError ? "#991b1b" : "#0c4a6e"
+      }}
+      role={isError ? "alert" : undefined}
+    >
+      {message}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,78 @@
+import type { ApiItemResponse, ApiListResponse, Product } from "@/lib/types";
+
+const DEFAULT_API_URL = "http://localhost:8000";
+
+function buildUrl(path: string) {
+  const base = process.env.NEXT_PUBLIC_API_URL || DEFAULT_API_URL;
+  return `${base.replace(/\/$/, "")}${path}`;
+}
+
+async function fetchJson<T>(path: string): Promise<ApiItemResponse<T>> {
+  try {
+    const res = await fetch(buildUrl(path), {
+      headers: { "Content-Type": "application/json" },
+      next: { revalidate: 30 }
+    });
+
+    if (!res.ok) {
+      return {
+        data: null,
+        error: res.status === 404 ? "Resource not found." : "The server responded with an error.",
+        status: res.status
+      };
+    }
+
+    const data = (await res.json()) as T;
+    return { data, error: null, status: res.status };
+  } catch (error) {
+    console.warn("Failed to fetch", error);
+    return {
+      data: null,
+      error: "We could not reach the server. Please check your connection and try again."
+    };
+  }
+}
+
+export async function getProducts(): Promise<ApiListResponse<Product>> {
+  const result = await fetchJson<Product[]>("/api/products/");
+  return {
+    data: result.data ?? [],
+    error: result.error
+  };
+}
+
+export async function getProduct(slug: string): Promise<ApiItemResponse<Product>> {
+  return fetchJson<Product>(`/api/products/${slug}/`);
+}
+
+export async function createOrder(payload: {
+  customer_name: string;
+  phone: string;
+  address: string;
+  note?: string;
+  items: { product: string; quantity: number }[];
+}): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const res = await fetch(buildUrl("/api/orders/"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      return {
+        ok: false,
+        error: body || "The server was unable to create the order."
+      };
+    }
+
+    return { ok: true };
+  } catch (error) {
+    console.error("Order submission failed", error);
+    return {
+      ok: false,
+      error: "We could not reach the server. Please try again."
+    };
+  }
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -1,0 +1,19 @@
+export type Product = {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  price_cents: number;
+  created_at: string;
+};
+
+export type ApiListResponse<T> = {
+  data: T[];
+  error: string | null;
+};
+
+export type ApiItemResponse<T> = {
+  data: T | null;
+  error: string | null;
+  status?: number;
+};

--- a/frontend/lib/util.ts
+++ b/frontend/lib/util.ts
@@ -1,0 +1,6 @@
+export function formatCurrency(cents: number) {
+  return new Intl.NumberFormat("mk-MK", {
+    style: "currency",
+    currency: "MKD"
+  }).format(cents / 100);
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "shop-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,28 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #f5f5f5;
+  color: #111827;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: #f5f5f5;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+main {
+  min-height: 100vh;
+}
+
+button {
+  cursor: pointer;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "es2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["components/*"],
+      "@/lib/*": ["lib/*"],
+      "@/styles/*": ["styles/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- resolve product detail lookups by slug and validate order payloads defensively
- load Jazzmin only when available and include it in the default backend requirements
- replace the missing frontend with a Next.js storefront that lists products, shows detail pages, keeps the cart in local storage, and handles offline/ordering errors gracefully

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68de7a0a822c833088ebb7a13d293c04